### PR TITLE
Ensure atomic Excel saving and add version utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+venv/
+__pycache__/
+*.pyc
+OUTPUT/
+PDF_TEXT_OUTPUT/
+error.log

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ Key features include a user-friendly Tkinter GUI, live pattern management, an in
 4. In the Review tab, flag an incorrect model (e.g., `TASKalfa-XYZ`) to ignore it in future scans.
 5. Add a new author pattern (e.g., `r"By:\s*(\w+\s\w+)"`) via Pattern Manager.
 
+### Export Flow
+1. After processing, the Excel report is written atomically to the `OUTPUT/` folder.
+2. Click **📂 Reveal in Folder** (Tip: press `Ctrl+F` to focus buttons) to open the report's location.
+3. Check `error.log` if something goes wrong.
+
+### Versions Tool
+Run `python tools/versions.py` to print the installed versions of Python, PyMuPDF, openpyxl, pytesseract, Pillow, and the Tesseract CLI.
+
 ## Project File Structure
 - `START.bat`: Windows launcher.
 - `run.py`: Sets up virtual environment and dependencies.

--- a/excel_processor.py
+++ b/excel_processor.py
@@ -3,10 +3,10 @@
 # Date: 2025-08-18 (Updated)
 # Version: VA-1.7 (Improved Auto-Formatting)
 
+import logging
 import openpyxl
 from util import excel_safe
 from openpyxl.styles import PatternFill, Font, Alignment
-from openpyxl.utils import get_column_letter
 from pathlib import Path
 from datetime import datetime
 
@@ -20,6 +20,8 @@ TOPIC_COL = "Topic"
 PRODUCT_DESC_COL = "Product Description"
 STATUS_COL = "Processing Status"
 SYS_ID_COL = "Sys ID"
+
+logger = logging.getLogger(__name__)
 
 def process_excel_file(template_path: Path, processed_data: list, output_dir: Path) -> Path:
     """
@@ -159,8 +161,8 @@ def process_excel_file(template_path: Path, processed_data: list, output_dir: Pa
                     # Find the longest line in the cell after splitting by newline
                     lines = str(cell.value).split("\n")
                     max_length = max(max_length, max(len(line) for line in lines))
-            except:
-                pass
+            except Exception as e:
+                logger.exception("Error measuring cell length: %s", e)
         
         # Add a little buffer, but cap the width at a reasonable maximum (e.g., 60)
         adjusted_width = min((max_length + 2) * 1.2, 60)

--- a/main_app.py
+++ b/main_app.py
@@ -64,8 +64,8 @@ def load_config():
         try:
             with open(CONFIG_FILE, 'r') as f:
                 return {**DEFAULT_CONFIG, **json.load(f)}
-        except:
-            pass
+        except Exception as e:
+            logger.exception("Failed to load config: %s", e)
     return DEFAULT_CONFIG
 
 def save_config(config):
@@ -73,8 +73,8 @@ def save_config(config):
     try:
         with open(CONFIG_FILE, 'w') as f:
             json.dump(config, f, indent=2)
-    except:
-        pass
+    except Exception as e:
+        logger.exception("Failed to save config: %s", e)
 
 def create_tooltip(widget, text):
     """Create a tooltip for a widget"""
@@ -257,8 +257,9 @@ class PatternManagerWindow(tk.Toplevel):
                 categories[field] = self.tree.insert("", "end", text=f"📁 {field}", open=True, tags=('category',))
             try:
                 re.compile(p["pattern"]); status = "✓ Valid"; tag = 'custom' if p["type"] == "Custom" else 'builtin'
-            except:
+            except re.error as e:
                 status = "✗ Invalid"; tag = 'error'
+                logger.exception("Invalid pattern %s: %s", p.get("pattern"), e)
             self.tree.insert(categories[field], "end", iid=f"pattern_{i}", text="", values=(p["pattern"], p["type"], status), tags=(tag,))
 
     def add_pattern(self):

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -1,0 +1,11 @@
+"""Tests for tools.versions."""
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from tools import versions
+
+
+def test_get_tesseract_cli_version_returns_string():
+    result = versions.get_tesseract_cli_version()
+    assert isinstance(result, str)

--- a/tools/versions.py
+++ b/tools/versions.py
@@ -2,7 +2,6 @@
 """Print versions of key dependencies."""
 import platform
 import subprocess
-import sys
 
 import fitz
 import openpyxl

--- a/util/excel_safe.py
+++ b/util/excel_safe.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import logging
 import os
 import tempfile
 from typing import Any
@@ -9,6 +10,7 @@ from typing import Any
 
 def ensure_output_dir(path: Path) -> None:
     """Ensure the output directory exists."""
+    logging.debug("Ensuring output directory %s", path)
     path.mkdir(parents=True, exist_ok=True)
 
 
@@ -19,12 +21,17 @@ def build_output_path(output_dir: Path, base_name: str) -> Path:
 
 def save_workbook_safely(workbook: Any, path: Path) -> None:
     """Atomically save *workbook* to *path* using a temporary file."""
+    logging.debug("Saving workbook to %s", path)
     ensure_output_dir(path.parent)
     with tempfile.NamedTemporaryFile(dir=path.parent, delete=False, suffix=path.suffix) as tmp:
         temp_name = tmp.name
     try:
         workbook.save(temp_name)
         os.replace(temp_name, path)
+        logging.info("Workbook saved to %s", path)
+    except Exception:
+        logging.exception("Failed to save workbook to %s", path)
+        raise
     finally:
         if os.path.exists(temp_name):
             os.remove(temp_name)


### PR DESCRIPTION
## Summary
- add logging-aware atomic Excel workbook saving helper
- improve error handling and logging in main_app and excel_processor
- document export flow and provide versions diagnostics tool

## Testing
- `ruff check util excel_processor.py main_app.py tools/versions.py tests/test_excel_safe.py --select F401,E722`
- `pytest -q`
- `python tools/versions.py`

------
https://chatgpt.com/codex/tasks/task_e_68b1270cd114832e890b6152eeb051e7